### PR TITLE
Initial docker/docker-compose setup for sim service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM julia:1.8
+
+WORKDIR /sim-service
+# Install requirements
+COPY Manifest.toml  /sim-service/
+COPY Project.toml /sim-service/
+RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate();'
+
+# Install local package
+COPY src/ /sim-service/src/
+RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.precompile();'
+RUN julia -e 'using Pkg; Pkg.activate("."); using SimService;'
+
+EXPOSE 8080
+CMD [ "julia", "-e", "using Pkg; Pkg.activate(\".\"); using SimService; SimService.run!();" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  sim-service:
+    build:
+      dockerfile: Dockerfile
+    container_name: sim-service
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/docs"]
+      interval: 30s
+      retries: 10
+    expose:
+      - 8080
+    ports:
+      - published: 8095
+        target: 8080
+    volumes:
+      - ./src:/sim-service/src
+

--- a/src/SimService.jl
+++ b/src/SimService.jl
@@ -25,7 +25,7 @@ function run!()
     register!()
     #document()
     # TODO(five)!: Stop SciML from slowing the server down. (Try `serveparallel`?)
-    serve()
+    serve(host="0.0.0.0")
 end
 
 end # module Pipeline


### PR DESCRIPTION
Adding initial basic docker an docker compose configuration.

Hopefully in the future this can be sped up as starting the service takes around 2 minutes locally, and the initial build of the image takes over 30 minutes.